### PR TITLE
ChatSpaceの自動更新

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,6 @@
 $(function(){
+  
+  
   function buildHTML(message){
     if ( message.image ) {
       var html =
@@ -12,7 +14,7 @@ $(function(){
           </div>
         </div>
          <div class="main__messages__message__text"></div>
-         ${message.content}
+            ${message.content}
          <br>
          <img class="lower-message__image" src=${message.image}>
        </div>`
@@ -34,7 +36,7 @@ $(function(){
         </div>`
       return html;
     };
-  }
+  };
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -57,7 +59,41 @@ $(function(){
     .fail(function() {
       alert("メッセージ送信に失敗しました");
       $('.form__submit').prop( 'disabled', false )
+    });
   });
-  })
+    var reloadMessages = function() {
+      //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      last_message_id = $('.main__messages__message:last').data("message-id");
+      $.ajax({
+        //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+        url: "api/messages",
+        //ルーティングで設定した通りhttpメソッドをgetに指定
+        type: 'get',
+        dataType: 'json',
+        //dataオプションでリクエストに値を含める
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        if (messages.length !== 0) {
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.main__messages').append(insertHTML);
+        $('.main__messages').animate({ scrollTop: $('.main__messages')[0].scrollHeight});
+        $("#new_message")[0].reset();
+        $(".form__submit").prop("disabled", false);
+      }
+      })
+      .fail(function() {
+        console.log('error');
+      });
+    };
+    if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+      setInterval(reloadMessages, 7000);
+    }
 });
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -14,14 +14,6 @@
       
   .main__messages
     = render @messages
-  -# .main__messageform
-  -#   .main__messageform__new
-  -#     .main__messageform__new__input
-  -#       %input.main__messageform__new__input__text{placeholder:  "type a message", type: "text"}/
-  -#       %label.main__messageform__new__input__image{for: "message_image"}
-  -#         %i.fa.fa-image
-  -#         %input#message_image.main__messageform__new__input__image__file{type: "file"}/
-  -#     %input.main__messageform__new__btn{type: "submit", value: "Send"}/
 
   .form
     = form_for [@group, @message] do |f|
@@ -33,11 +25,3 @@
       = f.submit 'Send', class: 'form__submit'
 
 
--#  .form
--#       = form_for [@group, @message] do |f|
--#         = f.text_field :content, class: 'form__message', placeholder: 'type a message'
--#         .form__mask
--#           = f.label :image, class: 'form__mask__image' do
--#             = icon('fas', 'image', class: 'icon')
--#             = f.file_field :image, class: 'hidden'
--#         = f.submit 'Send', class: 'form__submit'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main__messages__message
+.main__messages__message{data: {message: {id: message.id}}}
       .main__messages__message__info
             .main__messages__message__info__name 
                   = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,6 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+#idもデータとして渡す
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
- 
-   resources :users, only: [:index, :edit, :update]
-   resources :groups, only: [:new, :create, :edit, :update] do
+  resources :users, only: [:index, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
 
# what
ChatSpaceの自動更新の実装

# why
・新規投稿を取得できるようにする
新規メッセージ確認用のアクションを追加
アクションを呼び出せるようルーティングを追加
・投稿内容をレスポンスできるようにする
・取得した投稿データを表示できるようにする
取得した最新のメッセージをブラウザのメッセージ一覧に追加
数秒ごとにリクエストするように実装
・機能をブラッシュアップしよう
メッセージを取得したら画面がスクロールするよう実装
自動更新が必要ない画面では行わないよう実装

 